### PR TITLE
Sidebar Patch

### DIFF
--- a/src/Sidebar.js
+++ b/src/Sidebar.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { doc, getDoc, updateDoc ,arrayUnion, arrayRemove, setDoc } from 'firebase/firestore';
+import { doc, getDoc, updateDoc ,arrayUnion, arrayRemove, setDoc, deleteDoc, getDocs, collection} from 'firebase/firestore';
 import { db } from './firebase';
 import sidebarStyles from './SidebarStyles';
 import { getAuth, onAuthStateChanged } from "firebase/auth";
@@ -11,8 +11,6 @@ const Sidebar = ({ onSelectServer }) => {
 const [servers, setServers] = useState([]);
 const [contextMenu, setContextMenu] = useState({ visible: false, serverId: null, x: 0, y: 0 });
 const [uid, setUid] = useState(null);
-
-const auth = getAuth();
 
 
 useEffect(() => {
@@ -32,6 +30,11 @@ useEffect(() => {
     fetchServers();
   }
 }, [uid]);
+
+//clicks on Geoserver when page initially renders
+useEffect(() => {
+  handleServerClick('a', 'GeoServer');
+}, []); 
 
   const fetchServers = async () => {
       const userDoc = await getDoc(doc(db, 'users', uid));
@@ -59,21 +62,13 @@ useEffect(() => {
   };
 
 // Right-click menu
-  const handleContextMenu = (e, serverId) => {
+  const handleContextMenu = (e, index, serverId) => {
     e.preventDefault(); // Prevent the default context menu
-    setContextMenu({ visible: true, serverId, x: e.pageX, y: e.pageY });
+    setContextMenu({ visible: true, serverId, index, x: e.pageX, y: e.pageY });
   };
 
   const handleCloseContextMenu = () => {
     setContextMenu({ ...contextMenu, visible: false });
-  };
-
-
-  const handleLeaveServer = async () => {
-    const userRef = doc(db, 'users', uid);
-    await updateDoc(userRef, { Servers: arrayRemove(contextMenu.serverId) });
-    fetchServers(); // Refresh the server list
-    handleCloseContextMenu();
   };
 
 
@@ -83,15 +78,16 @@ useEffect(() => {
     const [isMainPopupVisible, setIsMainPopupVisible] = useState(false); 
     const [isJoinServerPopupVisible, setIsJoinServerPopupVisible] = useState(false);
     const [isCreateServerPopupVisible, setIsCreateServerPopupVisible] = useState(false);    
-    const [isServerNameUpdatePopupVisible, setIsServerNameUpdatePopupVisible] = useState(false);
+    const [isServerRenamePopupVisible, setIsServerRenamePopupVisible] = useState(false);
 
     const [inputJoinServer, setInputJoinServer] = useState('');
     const [newServerName, setNewServerName] = useState('');
     const [newServerId, setNewServerId] = useState('');
-    const [nameUpdate, setNameUpdate] = useState('');
+    const [Rename, setRename] = useState('');
 
     const [joinServerError, setJoinServerError] = useState('');  
     const [createServerError, setCreateServerError] = useState('');  
+    const [renameError, setRenameError] = useState('');
 
     const handleOpenMainPopup = () => setIsMainPopupVisible(true);
     const handleCloseMainPopup = () => setIsMainPopupVisible(false);
@@ -118,20 +114,30 @@ useEffect(() => {
       setCreateServerError('');
     };
 
-    const handleOpenServerNameUpdatePopup = () => {
+    const handleOpenServerRenamePopup = async() => {
       setContextMenu({ ...contextMenu, visible: false });
-      setIsServerNameUpdatePopupVisible(true);
+      // Fetch the server document to check if the user is an admin
+      const serverDocRef = doc(db, 'servers', contextMenu.serverId);
+      const serverDoc = await getDoc(serverDocRef);
+      const serverData = serverDoc.data();
+      if (serverData.Admin && serverData.Admin.includes(uid)) {
+        // User is an admin, proceed with renaming
+        setIsServerRenamePopupVisible(true);
+      } else {
+        alert("You do not have permission to rename this server.");
+      }
     };
   
-    const handleCloseServerNameUpdatePopup = () => {
-      setIsServerNameUpdatePopupVisible(false);
-      setNameUpdate('');
+    const handleCloseServerRenamePopup = () => {
+      setIsServerRenamePopupVisible(false);
+      setRename('');
+      setRenameError('');
     };
 
     const handleInputJoinServerChange = (e) => setInputJoinServer(e.target.value);
     const handleNewServerNameChange = (e) => setNewServerName(e.target.value);
     const handleNewServerIdChange = (e) => setNewServerId(e.target.value);
-    const handleNameUpdateChange = (e) => setNameUpdate(e.target.value);
+    const handleRenameChange = (e) => setRename(e.target.value);
 
     const checkIfServerExistsJoin = async () => {
       const checkIfServerExistsJoinRef = doc(db, 'servers', inputJoinServer);
@@ -145,6 +151,7 @@ useEffect(() => {
       return checkIfServerExistsCreateSnap.exists();
     };
 
+  //Functions tied to pop up boxes  
     const handleSubmitJoinServer = async(e) => {
       e.preventDefault();
       const joinRef = doc(db, 'users', uid);
@@ -156,12 +163,21 @@ useEffect(() => {
           setJoinServerError('Sever not found. Please enter a valid Server ID');
           return;
         }
-
+        //Register Server to the user's profile
         await updateDoc(joinRef, {Servers: arrayUnion(inputJoinServer)});
+
+        //Register User to the Server's member list.
+        await updateDoc(doc(db, 'servers', inputJoinServer), { Users: arrayUnion(uid) });
+
         setInputJoinServer('');
         setJoinServerError('');
         handleCloseJoinServerPopup();
         fetchServers();
+
+      // Clicking the new server by assuming the new server is added to the end of the servers list
+      const newIndex = servers.length;
+      handleServerClick(newIndex, inputJoinServer);
+
       } catch(error) {
         console.error('Error joining server:', error);
       }
@@ -180,31 +196,166 @@ useEffect(() => {
           setCreateServerError('Server ID already exists.  Try a different ID.');
           return;
         } else {
-          await setDoc(doc(db, 'servers', newServerId),
-          {description:"Default", 
-           image:`https://unsplash.it/600/400?image=${randomImageNumber}`,
-           name: newServerName})
-
-           await setDoc(doc(db, 'servers', newServerId, 'channels', 'Channel1'), {name: "Channel1"});
+          try {
+            // Create the server document with initial fields
+            await setDoc(doc(db, 'servers', newServerId), {
+              description: "Default",
+              image: `https://unsplash.it/600/400?image=${randomImageNumber}`,
+              name: newServerName
+            });
           
-           const createRef = doc(db, 'users', uid);
-           await updateDoc(createRef, {Servers: arrayUnion(newServerId)});
-        }
+            // Default Channel on Server Creation
+            await setDoc(doc(db, 'servers', newServerId, 'channels', 'Channel1'), { name: "Channel1" });
+          
+            // Add the Server to the user's profile in the database
+            const userRef = doc(db, 'users', uid);
+            await updateDoc(userRef, { Servers: arrayUnion(newServerId) });
+          
+            // Add the creator as an admin to the server
+            await updateDoc(doc(db, 'servers', newServerId), { Admin: arrayUnion(uid) });
+          
+            // Add the creator as a user to the server
+            await updateDoc(doc(db, 'servers', newServerId), { Users: arrayUnion(uid) });
+          
+          } catch (error) {
+            console.error("Error creating server:", error);
+          }};
       handleCloseCreateServerPopup();
       fetchServers();
+
+    // Clicking the new server by assuming the new server is added to the end of the servers list
+    const newIndex = servers.length;
+    handleServerClick(newIndex, newServerId);
+
       }catch(error) {
-        console.error('Error joining server:', error);
         setCreateServerError('Failed to create the server. Please try again');
       }
     };
 
-    const handleServerNameUpdate = async() => {
-      await updateDoc(doc(db, 'servers', contextMenu.serverId), {name: nameUpdate})
-    };
+  //Right-click menu functions
+        const handleDisplayServerId = async() => {
+          alert("Server Id =" + ' ' + contextMenu.serverId);
+        }
 
+        const handleServerRename = async(e) => {
+          e.preventDefault();
+          if (!Rename) {
+            setRenameError('Server name cannot be empty');
+            return;
+          }
+          try {
+              const serverDocRef = doc(db, 'servers', contextMenu.serverId);
+              await updateDoc(serverDocRef, { name: Rename });
+              handleCloseServerRenamePopup(); // Close the rename popup
+    
+              handleServerClick(contextMenu.index, contextMenu.serverId);
+              } 
+            catch (error) {
+            console.error("Error renaming server:", error);
+       }};
 
+       const handleLeaveServer = async () => {
+    
+        try {
+          // Fetch the server document to check if the user is an admin
+          const serverDocRef = doc(db, 'servers', contextMenu.serverId);
+          const serverDoc = await getDoc(serverDocRef);  
+          const serverData = serverDoc.data();
+      
+          // Check if the user ID is in the Admin array
+          if (serverData.Admin && serverData.Admin.includes(uid)) {
+            alert("The admin cannot leave the server, only delete.");
+            return; // Exit the function if the user is an admin
+          }
 
+          const confirmLeave = window.confirm("Are you sure you want to leave this server?");
+      
+          if (!confirmLeave) {
+            return; // Exit the function if cancelled
+          }
+      
+          // Proceed to remove the user from the server
+          const userRef = doc(db, 'users', uid);
+          await updateDoc(userRef, { Servers: arrayRemove(contextMenu.serverId) });
+          fetchServers(); // Refresh the server list
+          handleCloseContextMenu();
+          handleServerClick('a', 'GeoServer');
+      
+        } catch (error) {
+          console.error("Error leaving server:", error);
+          alert("An error occurred while trying to leave the server. Please try again.");
+        }
+      };
+  
+      const handleDeleteServer = async () => {
 
+        try {
+          // Fetch the server document to check if the user is an admin
+          const serverDocRef = doc(db, 'servers', contextMenu.serverId);
+          const serverDoc = await getDoc(serverDocRef);
+          const serverData = serverDoc.data();
+  
+            // Check if the user ID is in the Admin array
+            if (serverData.Admin && serverData.Admin.includes(uid)) {
+              // User is an admin, prompt for confirmation
+
+              const confirmDelete = window.confirm("Are you sure you want to delete this server? This action cannot be undone.");
+  
+              if (!confirmDelete) {
+                return; // Exit the function if cancelled
+              }
+
+              // Fetch all user IDs associated with this server
+              const userIDs = serverData.Users || [];
+
+              // Remove the server ID from each user's Servers array
+              const removePromises = userIDs.map(async (userId) => {
+              const userRef = doc(db, 'users', userId);
+              return updateDoc(userRef, { Servers: arrayRemove(contextMenu.serverId) });
+              });
+
+              // Wait for the server id to be removed from all registered users.
+              await Promise.all(removePromises);
+
+              // Fetch all channels in the server
+              const channelsCollectionRef = collection(serverDocRef, 'channels');
+              const channelsSnapshot = await getDocs(channelsCollectionRef);
+
+              // Prepare to delete messages in each channel
+              const deletePromises = channelsSnapshot.docs.map(async (channelDoc) => {
+              const messagesCollectionRef = collection(channelDoc.ref, 'messages'); 
+              const messagesSnapshot = await getDocs(messagesCollectionRef);
+
+              // Delete all messages in the channel
+              const messageDeletePromises = messagesSnapshot.docs.map(messageDoc => {
+              return deleteDoc(doc(messagesCollectionRef, messageDoc.id));
+              });
+
+              // Wait for all message delete operations in the current channel to complete
+              await Promise.all(messageDeletePromises);
+
+              // Delete the current channcel
+              await deleteDoc(channelDoc.ref);
+              });
+
+              // Wait for all channel delete operations to complete
+              await Promise.all(deletePromises);
+
+              // And finally delete the server
+              await updateDoc(doc(db, 'users', uid), { Servers: arrayRemove(contextMenu.serverId) });
+              await deleteDoc(doc(db, 'servers', contextMenu.serverId));
+              fetchServers(); // Refresh the server list
+              handleCloseContextMenu();
+              handleServerClick('a', 'GeoServer')
+            } else {
+              alert("You do not have permission to delete this server.");
+            }
+        } catch (error) {
+          console.error("Error deleting server:", error);
+     }};
+
+ //Main return
+  
   return (
     <div style={sidebarStyles.sidebar}
     onContextMenu={(e) => {
@@ -233,8 +384,10 @@ useEffect(() => {
           : sidebarStyles.serverIcon}  //changes sytle of the icon to match the container.  We can do something similar with active if we want to match discord more closely
           alt={'Geo'}
           />
-      
     </div> 
+
+      <div   style={{width: '50%',height: '1px',backgroundColor: '#404142',marginBottom: '15px'}}></div>
+
       {servers.map((server, index) => (
         <div
           key={server.id}
@@ -248,7 +401,7 @@ useEffect(() => {
           onClick={() => handleServerClick(index, server.id)}  //registers as clicked
           onMouseEnter={() => setHoveredIndex(index)}  //registers as hovered
           onMouseLeave={() => setHoveredIndex(null)}
-          onContextMenu={(e) => handleContextMenu(e, server.id)}
+          onContextMenu={(e) => handleContextMenu(e, index, server.id)}
         >
           <img
             src={server.image}
@@ -276,11 +429,17 @@ useEffect(() => {
           }}
           onMouseLeave={handleCloseContextMenu} // Close menu on mouse leave
         >
-          <div onClick={handleOpenServerNameUpdatePopup} style={{ padding: '8px', cursor: 'pointer' }}>
+          <div onClick={handleDisplayServerId} style={{ padding: '8px', cursor: 'pointer' }}>
+            Display Server Id
+          </div>
+          <div onClick={handleOpenServerRenamePopup} style={{ padding: '8px', cursor: 'pointer' }}>
             Change Name
           </div>
           <div onClick={handleLeaveServer} style={{ padding: '8px', cursor: 'pointer', color: 'red' }}>
             Leave Server
+          </div>
+          <div onClick={handleDeleteServer} style={{ padding: '8px', cursor: 'pointer', color: 'red' }}>
+            Delete Server
           </div>
         </div>
       )}
@@ -373,23 +532,24 @@ useEffect(() => {
         </div>
       )}
 
-{isServerNameUpdatePopupVisible && (
+{isServerRenamePopupVisible && (
         <div style={sidebarStyles.popup}>
           <div style={sidebarStyles.popupContent}>
             <h2>New Server Name</h2>
-            <form onSubmit={handleServerNameUpdate}>
+            <form onSubmit={handleServerRename}>
               <input
                 type="text"
-                value={nameUpdate}
-                onChange={handleNameUpdateChange}
+                value={Rename}
+                onChange={handleRenameChange}
                 style={sidebarStyles.input}
                 placeholder="New Name"
               />
+              {renameError && <p style={{ color: 'red' }}>{renameError}</p>}
               <div style={sidebarStyles.buttonContainer}>
                 <button type="submit" style={sidebarStyles.submitButton}>
                   Update
                 </button>
-                <button type="button" onClick={handleCloseServerNameUpdatePopup} style={sidebarStyles.closeButton}>
+                <button type="button" onClick={handleCloseServerRenamePopup} style={sidebarStyles.closeButton}>
                   Close
                 </button>
               </div>


### PR DESCRIPTION
Patch Notes:

**Renaming Servers**
When joining a server, the user's ID is added to a "Users" array in the Server's database entry

When creating a server, the user's ID is added to both a "Users" array and an "Admin" array in the Server's database entry.

To rename a server, the user's ID must be located in the "Admin" array in the Server's database entry.
           If this is not the case, an alert will display that the user does not have permission to rename the server.

Fixed a bug that was preventing the renaming from taking effect on occasion.  
          -I think the screen was occasionally refreshing before the code could execute.

**Deleting Servers**
An option to delete a server has been added to the contextual right click menu.

To delete a server, the user's ID must be located in the "Admin" array in the Server's database entry.
If this is not the case, an alert will display that the user does not have permission to delete the server.

If the ID matches, an alert box requests confirmation.
If confirmed,
The messages in each channel is deleted, then the channels themselves are deleted (Firestore doesn't delete subcollections automatically).

The server is deleted from the database.

For every user listed in the "Users" array, the Server ID is removed from their "Servers" array to no longer be displayed on the sidebar.

**General Functionality Improvements**
When the sidebar initially loads, the Geo Server is automatically clicked to make it the active server.

After renaming a server, it is automatically re-clicked to make it the active server and refresh the name.

When deleting or leaving a server, the Geo Server is automatically clicked to force it as the active server.

When creating or joining a server, the new Server is automatically clicked to make it the active server.

A confirmation alert now asks if you're sure you want to leave a server.

To avoid unpopulated servers, the server admin (creator) can not leave the server, only delete it.

A new "Display Server ID" option has been added to the right click menu.  When clicked an alert will pop up with the ID of the Server that was right clicked (in case the creator has forgotten the server ID).






